### PR TITLE
Compile project statically in MinGW environment

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ version: '8.4.4-{build}'
 
 environment:
   matrix:
-    - BUILD_TYPE: Release
+    - BUILD_TYPE: MinSizeRel
       COMPILER: MinGW
       PLATFORM: Win32
       WITH_MPFR: yes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: build
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    name: Build all
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-latest, cc: "gcc", cxx: "g++", build_type: "Release" }
+          - { os: ubuntu-latest, cc: "clang", cxx: "clang++", build_type: "Release" }
+          - { os: ubuntu-latest, cc: "x86_64-w64-mingw32-gcc", cxx: "x86_64-w64-mingw32-g++", build_type: "MinSizeRel",
+              toolchain: "cmake/Toolchain-MinGW64.cmake" }
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install g++-mingw-w64-x86-64 ninja-build
+      - name: Build with ${{ matrix.config.cc }}/${{ matrix.config.cxx }}
+        env:
+          CC: ${{ matrix.config.cc }}
+          CXX: ${{ matrix.config.cxx }}
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE=${{ matrix.config.toolchain }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+          cmake --build build -j2 -v
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: executables
+          path: build/int2ssl.exe
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.4.4 under development
 =====
+- Statically compile binary in MinGW environment (winterheart)
 
 8.4.3 (2018-01-03)
 =====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,16 @@
-set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build (by default Debug)")
-
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13)
 
 project(int2ssl)
 
-aux_source_directory(src SRC_LIST)
-
-add_definitions (-Wall)
-
-set(CMAKE_CXX_FLAGS_RELEASE "-Os -s")
-
-message("CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
-message("CMAKE_CXX_FLAGS_RELEASE is ${CMAKE_CXX_FLAGS_RELEASE}")
+option(STRIP_EXE "Strip debug info from compiled files" ON)
+file(GLOB_RECURSE SRC_LIST CONFIGURE_DEPENDS src/*.cpp)
 
 add_executable(${PROJECT_NAME} ${SRC_LIST})
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
+
+target_link_options(${PROJECT_NAME} PRIVATE
+	$<$<PLATFORM_ID:Windows>:-static>
+	$<$<BOOL:${STRIP_EXE}>:-s>
+)
+
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -26,13 +26,23 @@ Building from source:
 Dependencies:
 -------------
 
-- CMake (>= 2.8)
+- CMake (>= 3.13)
 
 Build:
 ------
 
 ```bash
 mkdir build && cd build && cmake .. && make
+```
+
+If you want cross-compile on Linux for Windows, you'll need to install MinGW
+toolchain and use special toolchain file:
+
+```bash
+sudo apt-get install g++-mingw-w64-x86-64
+mkdir build && cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-MinGW64.cmake
+make
 ```
 
 Usage:

--- a/cmake/Toolchain-MinGW64.cmake
+++ b/cmake/Toolchain-MinGW64.cmake
@@ -1,0 +1,22 @@
+# Toolchain file to cross compile on Linux targeting Windows (x64/mingw-w64).
+# Running:
+# cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/Toolchain-MinGW64.cmake ....
+
+set(CMAKE_SYSTEM_NAME Windows)
+
+set(MINGW_COMPILER_PREFIX "x86_64-w64-mingw32" CACHE STRING "What compiler prefix to use for mingw (i686-w64-mingw32 or x86_64-w64-mingw32)")
+set(MINGW_SYSROOT "/usr/${MINGW_COMPILER_PREFIX}" CACHE STRING "What sysroot to use for mingw")
+
+# Which compilers to use for C and C++
+find_program(CMAKE_C_COMPILER NAMES ${MINGW_COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${MINGW_COMPILER_PREFIX}-g++)
+find_program(CMAKE_RC_COMPILER NAMES ${MINGW_COMPILER_PREFIX}-windres)
+
+set(CMAKE_FIND_ROOT_PATH ${MINGW_SYSROOT})
+
+# Adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/src/XGetopt.cpp
+++ b/src/XGetopt.cpp
@@ -198,7 +198,7 @@ int getopt(int argc, char *argv[], const char *optstring)
     if (cp == NULL || c == ':')
         return '?';
 
-	cp++;
+    cp++;
     if (*cp == ':')
 	{
         if (*next != '\0')


### PR DESCRIPTION
In order to achieve more portability int2ssl needs to compiled with `-static` option in MinGW environment, so all required toolchain libraries gets compiled into binary. Partially fixes https://github.com/falltergeist/int2ssl/issues/6.

Now project supports cross-compiling for Windows binaries in Linux host. To do so, pass `-DCMAKE_TOOLCHAIN_FILE=/path/to/Toolchain-MinGW64.cmake` on cmake configuration phase.

Also reorganized CMakeLists.txt file for more modern CMake project best practies usage:
* -Os (optimized for size) is part of Cmake's MinSizeRel build type, so this option should'nt defined manually. Instead use `-DCMAKE_BUILD_TYPE=MinSizeRel`.
* -s (strip binary option) is not true crossplatform option, so moved it into option STRIP_EXE enabled by default.
* Minimal CMake version requirement updated to 3.13 to avoid deprecation warnings on modern cmake.

Additionally implemented GitHub Actions flows.